### PR TITLE
Inline propTypes checking code

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "homepage": "https://reactjs.org/",
   "dependencies": {
     "object-assign": "^4.1.1",
-    "prop-types": "^15.7.2",
     "react-is": "^16.12.0"
   },
   "devDependencies": {

--- a/src/shared/checkPropTypes.js
+++ b/src/shared/checkPropTypes.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {error as consoleError} from './consoleWithStackDev';
+
+let loggedTypeFailures = {};
+
+export default function checkPropTypes(
+  typeSpecs,
+  values,
+  location,
+  componentName,
+) {
+  if (process.env.NODE_ENV !== 'production') {
+    let has = Function.call.bind(Object.prototype.hasOwnProperty);
+    for (let typeSpecName in typeSpecs) {
+      if (has(typeSpecs, typeSpecName)) {
+        let error;
+        // Prop type validation may throw. In case they do, we don't want to
+        // fail the render phase where it didn't fail before. So we log it.
+        // After these have been cleaned up, we'll let them throw.
+        try {
+          // This is intentionally an invariant that gets caught. It's the same
+          // behavior as without this statement except with a better message.
+          if (typeof typeSpecs[typeSpecName] !== 'function') {
+            let err = Error(
+              (componentName || 'React class') +
+                ': ' +
+                location +
+                ' type `' +
+                typeSpecName +
+                '` is invalid; ' +
+                'it must be a function, usually from the `prop-types` package, but received `' +
+                typeof typeSpecs[typeSpecName] +
+                '`.' +
+                'This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.',
+            );
+            err.name = 'Invariant Violation';
+            throw err;
+          }
+          error = typeSpecs[typeSpecName](
+            values,
+            typeSpecName,
+            componentName,
+            location,
+            null,
+            'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED',
+          );
+        } catch (ex) {
+          error = ex;
+        }
+        if (error && !(error instanceof Error)) {
+          consoleError(
+            '%s: type specification of %s' +
+              ' `%s` is invalid; the type checker ' +
+              'function must return `null` or an `Error` but returned a %s. ' +
+              'You may have forgotten to pass an argument to the type checker ' +
+              'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' +
+              'shape all require an argument).',
+            componentName || 'React class',
+            location,
+            typeSpecName,
+            typeof error,
+          );
+        }
+        if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+          // Only monitor this failure once because there tends to be a lot of the
+          // same error.
+          loggedTypeFailures[error.message] = true;
+          consoleError('Failed %s type: %s', location, error.message);
+        }
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,7 +3553,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
The propTypes checking contract hasn't changed for years. It's stable.

Its source of truth lives in the prop-types package. However, we are inlining it in the React repo (https://github.com/facebook/react/pull/18127) to simplify React's ES Modules adoption story. We will do the same with the Object.assign polyfill. This PR mirrors the same change for the shallow renderer, too.

The goal is to get to a place where none of our transitive dependencies *require* CommonJS for bundling.

The other change here is that I reuse the existing React's mechanism for injecting the stack. Previously, shallow renderer did a special thing, which only worked for propTypes. Now we use a generic mechanism so if you call, for example, `React.createElement`, it will also get the right stack.

Easier to review without whitespace: https://github.com/NMinhNguyen/react-shallow-renderer/compare/inline-pt?w=1