### PR TITLE
Remove `module` field from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "16.13.0",
   "description": "React package for shallow rendering.",
   "main": "index.js",
-  "module": "esm/index.js",
   "repository": "https://github.com/NMinhNguyen/react-shallow-renderer.git",
   "keywords": [
     "react",


### PR DESCRIPTION
See https://github.com/facebook/react/pull/18187 for context.

@gaearon has suggested via Twitter DM to stop publishing ESM until there's a better story around it.