### PR TITLE
16.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-shallow-renderer",
-  "version": "16.14.0",
+  "version": "16.14.1",
   "description": "React package for shallow rendering.",
   "main": "index.js",
   "repository": "https://github.com/NMinhNguyen/react-shallow-renderer.git",


### PR DESCRIPTION
It appears that `npm publish` wasn't run from the `build` directory resulting in missing files.

Closes #96.