### PR TITLE
Allow .contextType on class based components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-shallow-renderer",
-  "version": "16.14.1",
+  "version": "16.14.2",
   "description": "React package for shallow rendering.",
   "main": "index.js",
   "repository": "https://github.com/NMinhNguyen/react-shallow-renderer.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-shallow-renderer",
-  "version": "16.14.2",
+  "version": "16.14.1",
   "description": "React package for shallow rendering.",
   "main": "index.js",
   "repository": "https://github.com/NMinhNguyen/react-shallow-renderer.git",

--- a/src/ReactShallowRenderer.js
+++ b/src/ReactShallowRenderer.js
@@ -500,7 +500,9 @@ See https://fb.me/react-invalid-hook-call for tips about how to debug and fix th
 
     this._rendering = true;
     this._element = element;
-    this._context = getMaskedContext(elementType.contextTypes, context);
+    this._context = element.contextType
+      ? context
+      : getMaskedContext(elementType.contextTypes, context);
 
     // Inner memo component props aren't currently validated in createElement.
     let prevGetStack;


### PR DESCRIPTION
Hi all,

the patch posted on https://github.com/enzymejs/enzyme/issues/2189 adds support for class based components that pass the context via .contextType. This is the part of the patch that applies to react-shallow-renderer.