### PR TITLE
Allow React 19 to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "rollup-plugin-strip-banner": "^1.0.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Add React 19 to the peer dependency, allowing this project to be used in react19 based projects